### PR TITLE
Merge interaction/comment enhancements from dev into main

### DIFF
--- a/TechMeter.API/Controllers/CommentsController.cs
+++ b/TechMeter.API/Controllers/CommentsController.cs
@@ -32,7 +32,7 @@ namespace TechMeter.API.Controllers
         [HttpPost("{lessonId}")]
         public async Task<ActionResult<Response<LessonCommentResponse>>> AddCommentToLesson([FromRoute] string lessonId, [FromBody] LessonCommentRequest request)
         {
-            var response = await mediator.Send(new AddLessonCommentCommand(GetUserId(), lessonId, request.Content));
+            var response = await mediator.Send(new AddLessonCommentCommand(GetUserId(), lessonId, request.Content,request.ParentCommentId!));
             return StatusCode((int)response.StatusCode, response);
         }
 
@@ -55,7 +55,7 @@ namespace TechMeter.API.Controllers
         }
 
         [HttpDelete("{Id}/lesson/{lessonId}")]
-        [Authorize(Roles = "provider,admin")]
+        [Authorize()]
         public async Task<ActionResult<Response<string>>> DeleteLessonCommentByIdAsync([FromRoute] string lessonId, [FromRoute] string Id)
         {
             var response = await mediator.Send(new DeleteLessonCommentCommand(lessonId, Id, GetUserId(), IsInRole()));

--- a/TechMeter.Application/DTO/LessonComment/LessonCommentRequest.cs
+++ b/TechMeter.Application/DTO/LessonComment/LessonCommentRequest.cs
@@ -11,5 +11,6 @@ namespace TechMeter.Application.DTO.LessonComment
     {
         [Required]
         public string Content { get; set; }
+        public string? ParentCommentId { get; set; } = null;
     }
 }

--- a/TechMeter.Application/DTO/LessonComment/LessonCommentResponse.cs
+++ b/TechMeter.Application/DTO/LessonComment/LessonCommentResponse.cs
@@ -11,6 +11,7 @@ namespace TechMeter.Application.DTO.LessonComment
         public string Id { get; set; }
         public string Content { get; set; }
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public string? ParentCommentId { get; set; }
         public bool IsEdited { get; set; } = false;
         public string UserId { get; set; }
         public string UserName { get; set; }
@@ -18,5 +19,6 @@ namespace TechMeter.Application.DTO.LessonComment
         public string? UserImage { get; set; }
         public string LessonId { get; set; }
         public int LikesCount { get; set; }
+        public List<LessonCommentResponse> Replies { get; set; } = new ();
     }
 }

--- a/TechMeter.Application/Features/Lesson/Command/AddLessonComment/AddLessonCommentCommand.cs
+++ b/TechMeter.Application/Features/Lesson/Command/AddLessonComment/AddLessonCommentCommand.cs
@@ -9,5 +9,5 @@ using TechMeter.Domain.Shared.Bases;
 
 namespace TechMeter.Application.Features.Lesson.Command.AddLessonComment
 {
-    public sealed record AddLessonCommentCommand(string userId, string LessonId, string Content) : IRequest<Response<LessonCommentResponse>>;
+    public sealed record AddLessonCommentCommand(string userId, string LessonId, string Content,string commentParentId) : IRequest<Response<LessonCommentResponse>>;
 }

--- a/TechMeter.Application/Features/Lesson/Command/AddLessonComment/AddLessonCommentCommandHandler.cs
+++ b/TechMeter.Application/Features/Lesson/Command/AddLessonComment/AddLessonCommentCommandHandler.cs
@@ -15,7 +15,7 @@ namespace TechMeter.Application.Features.Lesson.Command.AddLessonComment
     {
         public async Task<Response<LessonCommentResponse>> Handle(AddLessonCommentCommand request, CancellationToken cancellationToken)
         {
-            return await lessonCommentService.AddLessonComment(request.userId, request.LessonId, request.Content);
+            return await lessonCommentService.AddLessonComment(request.userId, request.LessonId, request.Content,request.commentParentId);
         }
     }
 }

--- a/TechMeter.Application/Interfaces/LessonComment/ILessonCommentService.cs
+++ b/TechMeter.Application/Interfaces/LessonComment/ILessonCommentService.cs
@@ -10,7 +10,7 @@ namespace TechMeter.Application.Interfaces.LessonComment
 {
     public interface ILessonCommentService
     {
-        Task<Response<LessonCommentResponse>> AddLessonComment(string userId, string LessonId, string content);
+        Task<Response<LessonCommentResponse>> AddLessonComment(string userId, string LessonId, string content, string? ParentCommentId = null);
         Task<Response<string>> DeleteLessonComment(string lessonId, string commentId, string userId, bool isAdmin = false);
         Task<Response<List<LessonCommentResponse>>> GetAllLessonComment(string UserId, string LessonId, bool isAdmin = false);
         //Task<Response<LessonCommentResponse>> GetLessonComment(string CommentId, string userId, bool isAdmin);

--- a/TechMeter.Domain/Models/LessonComment.cs
+++ b/TechMeter.Domain/Models/LessonComment.cs
@@ -18,6 +18,10 @@ namespace TechMeter.Domain.Models
         public string UserName { get; set; }
         public string UserEmail { get; set; }
         public string? UserImage { get; set; }
+        public string? ParentCommentId { get; set; }
+        public LessonComment? ParentComment { get; set; }
+        public ICollection<LessonComment> Replies { get; set; } = new List<LessonComment>();
+
         //public string LessonId { get; set; }
         public Lessons Lesson { get; set; }
         public User User { get; set; }

--- a/TechMeter.Infrastructure/EntitiesConfigurations/LessonCommentConfiguration.cs
+++ b/TechMeter.Infrastructure/EntitiesConfigurations/LessonCommentConfiguration.cs
@@ -23,7 +23,12 @@ namespace TechMeter.Infrastructure.EntitiesConfigurations
             builder.HasOne(b => b.User)
                 .WithMany(b => b.LessonComments)
                 .HasForeignKey(b => b.UserId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder.HasOne(b => b.ParentComment)
+                .WithMany(b => b.Replies)
+                .HasForeignKey(b => b.ParentCommentId)
+                .OnDelete(DeleteBehavior.Restrict);
         }
     }
 }

--- a/TechMeter.Infrastructure/Migrations/20260724202606_Applying a sub comment relation.Designer.cs
+++ b/TechMeter.Infrastructure/Migrations/20260724202606_Applying a sub comment relation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TechMeter.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using TechMeter.Infrastructure.Persistence;
 namespace TechMeter.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724202606_Applying a sub comment relation")]
+    partial class Applyingasubcommentrelation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TechMeter.Infrastructure/Migrations/20260724202606_Applying a sub comment relation.cs
+++ b/TechMeter.Infrastructure/Migrations/20260724202606_Applying a sub comment relation.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TechMeter.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Applyingasubcommentrelation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_lessonComments_AspNetUsers_UserId",
+                table: "lessonComments");
+
+            migrationBuilder.DropTable(
+                name: "UserFcmToken");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ParentCommentId",
+                table: "lessonComments",
+                type: "nvarchar(450)",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_lessonComments_ParentCommentId",
+                table: "lessonComments",
+                column: "ParentCommentId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_lessonComments_AspNetUsers_UserId",
+                table: "lessonComments",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_lessonComments_lessonComments_ParentCommentId",
+                table: "lessonComments",
+                column: "ParentCommentId",
+                principalTable: "lessonComments",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_lessonComments_AspNetUsers_UserId",
+                table: "lessonComments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_lessonComments_lessonComments_ParentCommentId",
+                table: "lessonComments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_lessonComments_ParentCommentId",
+                table: "lessonComments");
+
+            migrationBuilder.DropColumn(
+                name: "ParentCommentId",
+                table: "lessonComments");
+
+            migrationBuilder.CreateTable(
+                name: "UserFcmToken",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DeviceType = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Token = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserFcmToken", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserFcmToken_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserFcmToken_UserId",
+                table: "UserFcmToken",
+                column: "UserId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_lessonComments_AspNetUsers_UserId",
+                table: "lessonComments",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/TechMeter.Infrastructure/Services/LessonComment/LessonCommentAuthorization.cs
+++ b/TechMeter.Infrastructure/Services/LessonComment/LessonCommentAuthorization.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
 using TechMeter.Application.Interfaces.LessonComment;
@@ -47,25 +48,43 @@ namespace TechMeter.Infrastructure.Services.LessonComment
                 ))
                 .FirstOrDefaultAsync();
         }
-        public async Task<int> CanDeleteAsync(string userId, string CommentId, string LessonId )
+        public async Task<int> CanDeleteAsync(string userId, string CommentId, string LessonId)
         {
             var user = await context.Users.FindAsync(userId);
             var roles = await userManager.GetRolesAsync(user!);
-            if (roles.Contains("admin"))
+
+            bool isAdmin = roles.Contains("admin");
+            bool isProvider = roles.Contains("provider");
+            bool canDelete = false;
+
+            if (isAdmin)
             {
-                return await context.lessonComments.Where(b => b.Id == CommentId).ExecuteDeleteAsync();
+                canDelete = true;
             }
-            else if (roles.Contains("provider"))
+            else if (isProvider)
             {
-                return await context.lessonComments.Where(b => b.Id == CommentId && b.Lesson.section.Course.ProviderId == userId)
-                    .ExecuteDeleteAsync();
+                canDelete = await context.lessonComments.AnyAsync(c => c.Lesson.section.Course.ProviderId == userId);
             }
             else
             {
-                return await context.lessonComments
-                    .Where(b => b.LessonId == LessonId && b.UserId == userId && b.Id == CommentId)
-                    .ExecuteDeleteAsync();
+                canDelete = await context.lessonComments.AnyAsync(c => c.UserId == userId && c.LessonId == LessonId);
             }
+            if (!canDelete)
+                return 0;
+            var sql = @"
+        WITH CommentTree AS (
+            SELECT Id FROM lessonComments WHERE Id = {0}
+            
+            UNION ALL
+            
+            SELECT c.Id FROM lessonComments c
+            INNER JOIN CommentTree ct ON c.ParentCommentId = ct.Id
+        )
+        DELETE FROM lessonComments 
+        WHERE Id IN (SELECT Id FROM CommentTree)
+        OPTION (MAXRECURSION 0);";
+
+            return await context.Database.ExecuteSqlRawAsync(sql, CommentId);
         }
     }
 }

--- a/TechMeter.Infrastructure/Services/LessonComment/LessonCommentService.cs
+++ b/TechMeter.Infrastructure/Services/LessonComment/LessonCommentService.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using TechMeter.Application.DTO.Lesson;
 using TechMeter.Application.DTO.LessonComment;
 using TechMeter.Application.Interfaces.LessonComment;
+using TechMeter.Application.Interfaces.Notification;
 using TechMeter.Domain.Models;
 using TechMeter.Domain.Models.Auth.Identity;
 using TechMeter.Domain.Shared.Bases;
@@ -17,9 +18,9 @@ using TechMeter.Infrastructure.Persistence;
 namespace TechMeter.Infrastructure.Services
 {
     public class LessonCommentService(ApplicationDbContext context, ILessonCommentAuthorization lessonCommentAuthorization,
-        ResponseHandler responseHandler) : ILessonCommentService
+        ResponseHandler responseHandler, INotificationService notificationService) : ILessonCommentService
     {
-        public async Task<Response<LessonCommentResponse>> AddLessonComment(string userId, string lessonId, string content)
+        public async Task<Response<LessonCommentResponse>> AddLessonComment(string userId, string lessonId, string content, string? CommentParentId = null)
         {
             var user = await context.Users.FindAsync(userId);
             if (user == null)
@@ -31,7 +32,14 @@ namespace TechMeter.Infrastructure.Services
             {
                 return responseHandler.NotFound<LessonCommentResponse>("Lesson is not found");
             }
-
+            if (!string.IsNullOrEmpty(CommentParentId))
+            {
+                var CommentParentExists = await context.lessonComments.AnyAsync(b => b.Id == CommentParentId);
+                if (!CommentParentExists)
+                {
+                    return responseHandler.NotFound<LessonCommentResponse>("Comment Parent is not found");
+                }
+            }
             try
             {
                 if (!await lessonCommentAuthorization.HasCourseAccess(userId, Lesson.Value.CourseId))
@@ -50,10 +58,12 @@ namespace TechMeter.Infrastructure.Services
                     UserId = userId,
                     UserImage = user.ProfileUrl,
                     UserName = user.UserName ?? "",
+                    ParentCommentId = CommentParentId
 
                 };
                 await context.AddAsync(comment);
                 await context.SaveChangesAsync();
+                await notificationService.SendUserNotifications(comment.UserId, " new Comment", $"{user.UserName} added an new comment", Domain.Enums.NotificationType.Comment);
                 var response = new LessonCommentResponse
                 {
                     Id = comment.Id,
@@ -65,6 +75,7 @@ namespace TechMeter.Infrastructure.Services
                     UserId = comment.UserId,
                     UserImage = comment.UserImage,
                     UserName = comment.UserName,
+                    ParentCommentId = CommentParentId
                 };
                 return responseHandler.Success(response, "Comment Added Successfully");
             }
@@ -152,6 +163,7 @@ namespace TechMeter.Infrastructure.Services
                     UserId = comment.UserId,
                     UserImage = comment.UserImage,
                     UserName = comment.UserName,
+                    ParentCommentId = comment.ParentCommentId
                 };
                 return responseHandler.Success(response, "Comment Updated Successfully");
 
@@ -174,22 +186,44 @@ namespace TechMeter.Infrastructure.Services
                 return responseHandler.Forbidden<List<LessonCommentResponse>>("you don't have access to the course");
             }
 
-            var resposne = await context.lessonComments.Where(b => b.LessonId == LessonId)
-                .Select(b => new LessonCommentResponse
-                {
-                    Id = b.Id,
-                    Content = b.Content,
-                    LessonId = b.LessonId,
-                    CreatedAt = b.CreatedAt,
-                    IsEdited = b.IsEdited,
-                    UserEmail = b.UserEmail,
-                    UserId = b.UserId,
-                    UserImage = b.UserImage,
-                    UserName = b.UserName,
-                    LikesCount = b.LessonCommentLikes.Count(),
-                }).ToListAsync();
+            var comments = await context.lessonComments
+           .Where(c => c.LessonId == LessonId)
+           .AsNoTracking()
+           .OrderBy(c => c.CreatedAt)
+           .Select(c => new LessonCommentResponse
+           {
+               Id = c.Id,
+               Content = c.Content,
+               CreatedAt = c.CreatedAt,
+               IsEdited = c.IsEdited,
+               UserId = c.UserId,
+               UserName = c.UserName,
+               UserEmail = c.UserEmail,
+               UserImage = c.UserImage,
+               LessonId = c.LessonId,
+               LikesCount = c.LessonCommentLikes.Count(),
+               ParentCommentId = c.ParentCommentId
+           })
+           .ToListAsync();
 
-            return responseHandler.Success(resposne, "Lesson Comments Retrived Successfully");
+            var lookup = comments.ToDictionary(c => c.Id);
+
+            List<LessonCommentResponse> rootComments = [];
+
+            foreach (var comment in comments)
+            {
+                if (comment.ParentCommentId is null)
+                {
+                    rootComments.Add(comment);
+                }
+                else if (lookup.TryGetValue(comment.ParentCommentId, out var parent))
+                {
+                    parent.Replies.Add(comment);
+                }
+            }
+
+
+            return responseHandler.Success(rootComments, "Lesson Comments Retrived Successfully");
         }
 
         public async Task<Response<List<LessonCommentLikesResponse>>> GetCommentLikesAsync(string commentId, string userId, bool isAdmin = false)
@@ -259,6 +293,7 @@ namespace TechMeter.Infrastructure.Services
                     };
                     await context.LessonCommentLikes.AddAsync(lessonCommentLike);
                     await context.SaveChangesAsync();
+                    await notificationService.SendUserNotifications(comment.UserId, "Like on Your Comment", $"{user.UserName} Liked on your comment", Domain.Enums.NotificationType.Like);
                     return responseHandler.Success(string.Empty, "Like added successfully");
                 }
                 return responseHandler.Success(string.Empty, "Like already added");


### PR DESCRIPTION

**Title:**
Merge interaction/comment enhancements from `dev` into `main`

**Description:**
- Added support for `SubComments` in the comment system
- Improved lesson comment handling in `LessonCommentService`
- Updated API endpoints in `TechMeter.API/Controllers/CommentsController.cs`
- Added new DTOs and CQRS command/handler for lesson comments
- Created `LessonComment` entity and configuration in `TechMeter.Domain`
- Updated EF Core migration for sub-comment relationships
- Included authorization support via `LessonCommentAuthorization`

**Files touched:**
- `TechMeter.API/Controllers/CommentsController.cs`
- `TechMeter.Application/Features/.../LessonComment/...`
- `TechMeter.Domain/Models/LessonComment.cs`
- `TechMeter.Infrastructure/Persistence/Migrations/...`

> This merge brings completed interaction and comment module updates from `dev` into `main`.

Closes #16 